### PR TITLE
Switch Pages to main/docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Kadena Pact Community Foundation
+
+Welcome. This is the official GitHub Pages site for our community foundation.
+
+## Mission
+Make it easy and safe for businesses to start building on Kadena.
+
+## Vision
+A thriving Kadena ecosystem where new and existing businesses can launch confidently, supported by trusted, audited smart contracts and ready-to-use building blocks.


### PR DESCRIPTION
This moves the Pages site to main/docs by copying current gh-pages index.md to docs/index.md and prepares settings switch.