### PR TITLE
US11: Define CODEOWNERS for Wiki and Pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
-# All Wiki and Pages content
-* @DaisukeFlowers
+## CODEOWNERS for Wiki and Pages
+# GitHub Pages content (served from docs/)
+/docs/** @DaisukeFlowers
+
+# Pages sync workflow
+/.github/workflows/wiki-sync.yml @DaisukeFlowers
+
+# Optional: top-level Pages index and mapping file (redundant due to /docs/**)
+/docs/index.md @DaisukeFlowers
+/docs/wiki-home.md @DaisukeFlowers


### PR DESCRIPTION
Implements Issue #11.\n\n- Scopes CODEOWNERS to Pages content under `docs/` and the wiki sync workflow file.\n- Assigns ownership to @DaisukeFlowers (current repo admin).\n- Ensures PRs that modify Pages content require approval from the assigned CODEOWNER (paired with branch protection).\n\nNote: Wiki repo has its own git repository; adding a CODEOWNERS there as well.\n\nCloses none automatically; will keep Issue #11 open for your review.