### PR TITLE
US12: Update README with mission, vision, and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Sync Wiki to Docs](https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml/badge.svg)](https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml)
 
-Welcome. This repository is the front door for our community work on Kadena smart contracts and tooling.
+Welcome to the Kadena Pact Community Foundation. This repository is the front door for our community’s smart contract libraries, documentation, and processes around building on Kadena.
 
 ## Mission
 Make it easy and safe for businesses to start building on Kadena.
@@ -10,16 +10,25 @@ Make it easy and safe for businesses to start building on Kadena.
 ## Vision
 A thriving Kadena ecosystem where new and existing businesses can launch confidently, supported by trusted, audited smart contracts and ready-to-use building blocks.
 
-## Resources
-- [Wiki](https://github.com/Kadena-Pact-Community-Foundation/foundation/wiki) - Primary documentation (automatically synced to Pages)
-- [Pages](https://Kadena-Pact-Community-Foundation.github.io/foundation) - Public-facing site with Wiki content
-- [Discussions](https://github.com/Kadena-Pact-Community-Foundation/foundation/discussions)
+## Documentation & Links
+- Wiki (official documentation): https://github.com/Kadena-Pact-Community-Foundation/foundation/wiki
+- GitHub Pages (public site from `main/docs`): https://Kadena-Pact-Community-Foundation.github.io/foundation
+- Community Discussions: https://github.com/Kadena-Pact-Community-Foundation/foundation/discussions
 
-## Wiki to Pages Sync
-Wiki content is automatically mirrored to GitHub Pages for public visibility. The sync happens:
-- When Wiki pages are updated (via `gollum` event)
-- Manually via the Actions tab (`workflow_dispatch`)
+## About This Repository
+This repo hosts the Foundation’s public documentation and coordination artifacts. It is the central place to learn about our mission, vision, roadmap, contribution guidelines, and how to participate in the Kadena Pact ecosystem.
 
-Use the badge above or visit the Action to trigger a manual sync: https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml
+## Contributing
+We welcome contributors of all experience levels. Start with the Wiki’s Contribute page to learn how to propose changes, discuss ideas, and submit pull requests:
+- Contribute guide: https://github.com/Kadena-Pact-Community-Foundation/foundation/wiki/Contribute
+- Code of Conduct: https://github.com/Kadena-Pact-Community-Foundation/foundation/wiki/Code-of-Conduct
 
-The workflow mirrors selected Wiki markdown files to the `docs/` directory for Pages.
+## Wiki ⇄ Pages Sync
+Our Wiki content is mirrored to GitHub Pages for broader visibility.
+- Source of truth: Wiki pages in this repository
+- Pages build source: `main/docs` on this repo (generated from Wiki)
+- Triggers: Wiki updates (`gollum`) and manual runs via Actions
+
+Manual sync: https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml
+
+The workflow copies selected Wiki markdown files into `docs/` and maintains links so they render correctly on Pages.


### PR DESCRIPTION
Implements US12.\n\n- Adds clearly framed Mission and Vision\n- Adds Documentation & Links section with Wiki and GitHub Pages (explicitly noting Pages builds from main/docs) and Discussions\n- Adds welcoming Contributing section linking to Contribute and Code of Conduct\n- Refines purpose statement (About This Repository)\n- Keeps Wiki ⇄ Pages sync info, clarifies triggers and manual run link\n\nThis aligns README with the Foundation’s mission, vision, and documentation sources.\n\nCloses #12