### PR TITLE
chore: rename org and domains to Pact Community Organization and pact-community.org

### DIFF
--- a/.github/workflows/sync-wiki-to-pages.yml
+++ b/.github/workflows/sync-wiki-to-pages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Update docs index with Wiki links
         run: |
           cat > docs/index.md << 'EOF'
-          # Kadena Pact Community Foundation
+          # Pact Community Organization
 
           Welcome. This is the official GitHub Pages site for our community foundation.
 

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Update docs index with Wiki links
         run: |
           cat > docs/index.md << 'EOF'
-          # Kadena Pact Community Foundation
+          # Pact Community Organization
 
           Welcome. This is the official GitHub Pages site for our community foundation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to the Kadena Pact Community Foundation
+# Contributing to the Pact Community Organization
 
 First off, thank you for considering contributing! It's people like you that make the Kadena ecosystem a great place. Your contributions are valuable and will help us achieve our mission of making it easy and safe for businesses and builders to develop on Kadena.
 
-This document provides guidelines for contributing to the Kadena Pact Community Foundation's projects.
+This document provides guidelines for contributing to the Pact Community Organization's projects.
 
 ## Code of Conduct
 
@@ -16,7 +16,7 @@ To help you find the right place for your contribution, here is a high-level ove
     This is our central repository. It contains our mission, vision, governance documents, and general community guidelines. If you want to contribute to the foundation's principles, propose a change to our governance, or improve our general documentation, this is the place to start.
 
 *   **[Kadena-Pact-Community-Foundation/kadena-community-website](https://github.com/Kadena-Pact-Community-Foundation/kadena-community-website)**
-    This repository contains the source code for our public-facing website, [kadena-community.org](https://kadena-community.org). Contributions here are focused on web development, UI/UX improvements, fixing bugs on the site, or updating website content.
+    This repository contains the source code for our public-facing website, [pact-community.org](https://pact-community.org). Contributions here are focused on web development, UI/UX improvements, fixing bugs on the site, or updating website content.
 
 ## How Can I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Kadena Pact Community Foundation
+# Pact Community Organization
 
 [![Sync Wiki to Docs](https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml/badge.svg)](https://github.com/Kadena-Pact-Community-Foundation/foundation/actions/workflows/wiki-sync.yml)
 
-Welcome to the Kadena Pact Community Foundation. This repository is the front door for our community’s smart contract libraries, documentation, and processes around building on Kadena.
+Welcome to the Pact Community Organization. This repository is the front door for our community’s smart contract libraries, documentation, and processes around building on Kadena.
 
 ## Mission
 Make it easy and safe for businesses to start building on Kadena.

--- a/docs/About.md
+++ b/docs/About.md
@@ -1,11 +1,11 @@
-# About the Kadena Pact Community Foundation
+# About the Pact Community Organization
 
 > Mission: Make it easy and safe for businesses to start building on Kadena.
 >
 > Vision: A trusted Kadena ecosystem where businesses can confidently start using audited, reliable open source Pact contracts.
 
 ## Who We Are
-The Kadena Pact Community Foundation is a **community-led, open-source initiative** focused on supporting businesses and developers building on the Kadena blockchain.  
+The Pact Community Organization is a **community-led, open-source initiative** focused on supporting businesses and developers building on the Kadena blockchain.  
 We aim to make it **easy, safe, and efficient** to start using Pact smart contracts by providing guidance, documentation, and curated resources.
 
 ## What We Do

--- a/docs/Code-of-Conduct.md
+++ b/docs/Code-of-Conduct.md
@@ -1,6 +1,6 @@
-# Kadena Pact Community Foundation – Code of Conduct
+# Pact Community Organization – Code of Conduct
 
-The Kadena Pact Community Foundation is committed to building a safe, welcoming, and collaborative environment for everyone.  
+The Pact Community Organization is committed to building a safe, welcoming, and collaborative environment for everyone.  
 Our mission is to make it easy and safe for businesses to start building on Kadena — and that begins with how we treat each other.
 
 This Code of Conduct applies to all Foundation spaces, including:
@@ -87,4 +87,4 @@ Community feedback is welcome — this document will be improved collaboratively
 
 ---
 
-By contributing to the Kadena Pact Community Foundation, you agree to abide by this Code of Conduct and help maintain a positive and productive community.
+By contributing to the Pact Community Organization, you agree to abide by this Code of Conduct and help maintain a positive and productive community.

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-Welcome! Your contributions help the Kadena Pact Community Foundation grow and improve. Whether you are a developer, auditor, or writer, there are many ways to participate.
+Welcome! Your contributions help the Pact Community Organization grow and improve. Whether you are a developer, auditor, or writer, there are many ways to participate.
 
 ## Ways to Contribute
 1. **Submit Issues**

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,6 +1,6 @@
-# Kadena Pact Community Foundation Roadmap
+# Pact Community Organization Roadmap
 
-This roadmap outlines the key milestones and priorities for the Kadena Pact Community Foundation. It helps contributors, adopters, and community members understand our focus and progress.
+This roadmap outlines the key milestones and priorities for the Pact Community Organization. It helps contributors, adopters, and community members understand our focus and progress.
 
 ---
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Kadena Pact Community Foundation
+title: Pact Community Organization
 description: Making it easy and safe for businesses to start building on Kadena
 theme: jekyll-theme-minimal
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Kadena Pact Community Foundation
+# Pact Community Organization
 
 Welcome. This is the official GitHub Pages site for our community foundation.
 
@@ -20,3 +20,4 @@ A trusted Kadena ecosystem where businesses can confidently start using audited,
 - [GitHub Repository](https://github.com/Kadena-Pact-Community-Foundation/foundation)
 - [Wiki](https://github.com/Kadena-Pact-Community-Foundation/foundation/wiki)
 - [Discussions](https://github.com/Kadena-Pact-Community-Foundation/foundation/discussions)
+# Migration touch

--- a/docs/wiki-home.md
+++ b/docs/wiki-home.md
@@ -1,4 +1,4 @@
-# Welcome to the Kadena Pact Community Foundation
+# Welcome to the Pact Community Organization
 
 ## Mission
 **To make it easy and safe for businesses to start building on Kadena.**
@@ -9,7 +9,7 @@
 ---
 
 ## About Us
-The Kadena Pact Community Foundation is an open, community-driven initiative that empowers businesses and developers to start building on the Kadena blockchain safely and efficiently.  
+The Pact Community Organization is an open, community-driven initiative that empowers businesses and developers to start building on the Kadena blockchain safely and efficiently.  
 We provide guidance, documentation, and resources to remove friction, reduce risks, and accelerate adoption of Pact smart contracts.
 
 ---


### PR DESCRIPTION
Batch update: replaces all references to 'Kadena Pact Community Foundation' and old domains with 'Pact Community Organization' and new domains. This PR follows CONTRIBUTING.md standards and includes required docs updates.