### PR TITLE
chore(docs): remove/replace Kadena branding with Pact equivalents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the Pact Community Organization
 
-First off, thank you for considering contributing! It's people like you that make the Kadena ecosystem a great place. Your contributions are valuable and will help us achieve our mission of making it easy and safe for businesses and builders to develop on Kadena.
+First off, thank you for considering contributing! It's people like you that make the Pact ecosystem a great place. Your contributions are valuable and will help us achieve our mission of making it easy and safe for businesses and builders to develop with Pact.
 
 This document provides guidelines for contributing to the Pact Community Organization's projects.
 
@@ -49,4 +49,4 @@ If you are looking for a place to start, check for issues tagged with `good firs
 
 ## Any Questions?
 
-If you have any questions, feel free to join our [Kadena Discord Server](https://discord.gg/kadena) and ask in the relevant channels. We're here to help!
+If you have any questions, feel free to join our [Community Discord](https://discord.gg/kadena) and ask in the relevant channels. We're here to help!


### PR DESCRIPTION
This PR replaces organization/site-visible occurrences of 'Kadena' with 'Pact' variants in contributor-facing docs. Changes are conservative: external Kadena links (e.g., docs.kadena.io) are left intact. Files changed: CONTRIBUTING.md. Items that may need legal review (trademark/legal mentions) were flagged and left for manual review.