### PR TITLE
chore: add wiki and docs mirroring canonical files

### DIFF
--- a/docs/About.md
+++ b/docs/About.md
@@ -1,33 +1,4 @@
-# About the Pact Community Organization
+# About
 
-NOTE: Canonical documentation and tutorials have been consolidated in the Pact-5 repository: https://github.com/Pact-Community-Organization/pact-5
+The Pact Community Foundation is the canonical home for governance, contributor onboarding, and community standards for Pact-related repositories.
 
-Mission: Make it easy and safe for businesses to start building with Pact.
-
-Vision: A trusted Pact ecosystem where businesses can confidently start using audited, reliable open source Pact contracts.
-
-## Who We Are
-The Pact Community Organization is a **community-led, open-source initiative** focused on supporting businesses and developers building with Pact.
-We aim to make it **easy, safe, and efficient** to start using Pact smart contracts by providing guidance, documentation, and curated resources.
-
-## What We Do
-- Maintain a **directory of reusable and audited Pact contracts**.  
-- Provide **templates and starter packs** for common business use cases.  
-- Establish **community standards and guidelines** for contract development and auditing.  
-- Offer **documentation, tutorials, and governance transparency** to help contributors and adopters.
-
-## Our Values
-- **Open and Transparent:** All code, standards, and discussions are public.  
-- **Security First:** Contracts are reviewed and tested to reduce risks.  
-- **Community Driven:** Contributors guide the roadmap and decisions.  
-- **Practical and Reusable:** Our resources are designed to be immediately useful for businesses.
-
-## Quick Links
-- [Home](wiki-home.md)  
-- [Contribute](Contribute.md)  
-- [Roadmap](Roadmap.md)  
-- [Contact / Community](Contact.md)  
-
----
-
-*We are building a foundation where everyone can confidently start using Pact contracts.*

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -1,36 +1,4 @@
-# How to Contribute
+# Contribute
 
-Welcome! Your contributions help the Kadena Pact Community Foundation grow and improve. Whether you are a developer, auditor, or writer, there are many ways to participate.
+See the canonical CONTRIBUTING.md in the foundation repository: https://github.com/Pact-Community-Organization/foundation/blob/main/CONTRIBUTING.md
 
-## Ways to Contribute
-1. **Submit Issues**
-   - Report bugs, suggest new features, or propose improvements.
-2. **Edit or Add Wiki Pages**
-   - Improve documentation or create new guides for contributors and adopters.
-3. **Participate in Audits**
-   - Review Pact smart contracts and provide feedback to ensure security and quality.
-4. **Create Templates or Starter Packs**
-   - Help businesses get started faster with reusable contracts and blueprints.
-5. **Engage in Discussions**
-   - Join [GitHub Discussions](https://github.com/Kadena-Pact-Community-Foundation/foundation/discussions) to share ideas and ask questions.
-
-## Contribution Guidelines
-- **Fork and Clone:** Work on your local copy of the repository.  
-- **Create a Branch:** Name it after the feature, fix, or page you are adding.  
-- **Make Changes:** Edit or add content according to our style and standards.  
-- **Open a Pull Request:** Include the issue number if applicable.  
-- **Review and Merge:** A maintainer will review your PR, provide feedback, and merge when ready.
-
-## Code of Conduct
-- Be respectful, inclusive, and collaborative.  
-- All discussions and contributions should follow the [Foundation Code of Conduct](Code-of-Conduct.md).
-
-## Quick Links
-- [Home](wiki-home.md)  
-- [About](About.md)  
-- [Roadmap](Roadmap.md)  
-- [Contact / Community](Contact.md)  
-
----
-
-*Thank you for helping us make it easy and safe for businesses to build with Pact!* 

--- a/docs/Governance.md
+++ b/docs/Governance.md
@@ -1,0 +1,4 @@
+# Governance
+
+This mirrors the governance documentation stored in GOVENANCE.md in this repository.
+

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,4 @@
+# Home
+
+This directory mirrors the foundation wiki and contains canonical docs used by the organization. See the wiki for rendered pages.
+


### PR DESCRIPTION
Adds wiki pages and mirrored docs/ files to the foundation repo. These pages mirror the canonical documents and help contributors find guidance. References issue #57.