### PR TITLE
chore: propose teams and initial permissions

### DIFF
--- a/docs/teams.md
+++ b/docs/teams.md
@@ -1,0 +1,21 @@
+# Teams and Initial Permissions
+
+This document describes the teams to create for the Pact Community Organization and suggested initial permissions.
+
+## Teams to create
+
+- **Core-Maintainers**: permission `maintain` on core repositories. Responsibilities: code review, merges, releases, governance.
+- **Website-Team**: permission `maintain` on `website`. Responsibilities: website content, pages, deployments.
+- **Catalog-Team**: permission `maintain` on `pact-contract-catalog`. Responsibilities: catalog maintenance, metadata validation, contract onboarding.
+- **Security-WG**: permission `triage` (or `maintain`) across repos as needed. Responsibilities: vulnerability triage and coordination.
+
+## Initial assignments
+
+- `DaisukeFlowers`: org owner and team maintainer for all teams.
+
+## Notes
+
+- Creating teams requires org admin privileges. After this PR is merged, a follow-up step will create the teams via `gh team create` (or org admin UI). This PR documents the desired team names and permissions.
+
+References: Issue: https://github.com/Pact-Community-Organization/foundation/issues/57
+


### PR DESCRIPTION
Proposes organization teams (Core-Maintainers, Website-Team, Catalog-Team, Security-WG) and initial permission mapping. After this PR is merged, I will create the teams via GitHub CLI or API if you instruct me to proceed. References issue #57.