### PR TITLE
chore: add sync workflow scaffold, labels, and security runbook

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,23 @@
+# Standard labels for Pact Community Organization
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+
+- name: security
+  color: 5319e7
+  description: Security issue or vulnerability
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
 labels:
   - name: bug
     color: ff0000

--- a/.github/workflows/sync-foundation.yml
+++ b/.github/workflows/sync-foundation.yml
@@ -1,0 +1,48 @@
+name: Sync canonical files
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare files
+        run: |
+          mkdir -p deploy
+          cp -r .github deploy/.github || true
+          cp -r docs deploy/docs || true
+          cp SECURITY.md deploy/SECURITY.md || true
+
+      - name: Create PR to target repos
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const targetRepos = [
+              {owner: 'Pact-Community-Organization', repo: 'website', base: 'main'},
+              {owner: 'Pact-Community-Organization', repo: 'pact-contract-catalog', base: 'master'}
+            ]
+            const filesToCopy = ['.github/CODEOWNERS','docs','SECURITY.md']
+            for (const t of targetRepos) {
+              const branch = `sync/foundation-${t.repo}-${Date.now()}`
+              await github.rest.git.createRef({
+                owner: t.owner,
+                repo: t.repo,
+                ref: `refs/heads/${branch}`,
+                sha: (await github.rest.repos.getCommit({owner: t.owner, repo: t.repo, ref: t.base})).data.sha
+              }).catch(e=>{})
+              // Note: This job requires a token with repo write permission on target repos.
+              // This script is a placeholder — set up an org-level PAT in a secret named ORG_SYNC_TOKEN and replace github the auth if you want automated pushes.
+            }
+
+      - name: Note about manual steps
+        run: |
+          echo "This workflow is a draft: to enable automated PRs you must set a secret named ORG_SYNC_TOKEN with a PAT that has repo permissions for the target repositories."

--- a/SECURITY_RUNBOOK.md
+++ b/SECURITY_RUNBOOK.md
@@ -1,0 +1,21 @@
+## Security Runbook (Draft)
+
+Purpose: provide a minimal, practical response playbook for common security events.
+
+1. Triage
+   - Assign a Security WG member.
+   - Create a private issue (if sensitive) and label `security`.
+
+2. Containment
+   - If code is vulnerable, open a draft PR with the fix in a private branch.
+   - Revoke any compromised tokens/secrets and rotate keys.
+
+3. Communication
+   - Notify maintainers and org owners.
+   - For public incidents, prepare coordinated disclosure timeline.
+
+4. Post-Incident
+   - Run a security post-mortem.
+   - Update docs and checklist in `SECURITY.md`.
+
+This runbook is intentionally short — expand with contact info and process details as needed.


### PR DESCRIPTION
Adds a draft sync workflow (requires org PAT secret to operate), canonical labels file, and a short security runbook. This is Phase 3 scaffolding for syncing canonical files across repos. See tracking issue #57.